### PR TITLE
setup.py: Fix module installation

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ setup(
     author='David McClure',
     author_email='dclure@mit.edu',
     url='https://github.com/davidmcclure/cleanconfig',
-    packages=find_packages(),
+    py_modules=['cleanconfig'],
     license='MIT',
     install_requires=[
         'anyconfig',


### PR DESCRIPTION
Currently, cleanconfig doesn't install properly without the `-e` option;
it doesn't install the cleanconfig module, but it does install all of
the test modules.  Fix this by explicitly specifying the cleanconfig
module using `py_modules` instead of generically using `find_packages`.

Noticed when working on https://github.com/opensyllabus/osp-pipeline/pull/58.